### PR TITLE
Given a more descriptive message when no files are provided.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
 		}
 		// we dont do streams (yet)
 		if (file.isStream()) {
-			return this.emit('error', new PluginError('gulp-ui5-preload', 'File Content streams not yet supported'));
+			return this.emit('error', new gutil.PluginError('gulp-ui5-preload', 'File Content streams not yet supported'));
 		}
 		if (!firstFile && file) {
 			firstFile = file;

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ module.exports = function (options) {
 
 	function pushCombinedFileToStream() {
 
+		if(!firstFile){
+			return this.emit('error', new gutil.PluginError('gulp-ui5-preload', 'No files were provided. Wrong path ?'));
+		}
+		
 		gutil.log('gulp-ui5-preload',
 			gutil.colors.magenta(
 				'number of files combined to preload file ' + options.fileName + ': ',


### PR DESCRIPTION
if the user tries this
      gulp.src([‘WRONG_PATH’]).pipe(ui5preload({base:'src/main/ui',namespace:' ui'}))
this error will appear because the path is invalid or doesn't have any file.
      Cannot read property 'clone' of undefined.
Which is not very informative.
