### PR TITLE
Allows for special String.prototype.replace strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,9 @@ module.exports = function (options) {
 			'\t'
 		);
 
-		var contents = template.replace('JSON_CONTENT', jsonContent);
+		var contents = template.replace('JSON_CONTENT', function () {
+			return jsonContent;
+		});
 
 		var preloadFile = firstFile.clone({contents: false});
 		preloadFile.contents = new Buffer(contents);


### PR DESCRIPTION
Allows for the special strings of String.prototype.replace to occur in code. This is achieved by passing a function (which will not touch those special strings) instead of passing a plain string into String.prototype.replace

see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter